### PR TITLE
update semantic-ui .css reference.

### DIFF
--- a/candidates/templates/candidates/counties.html
+++ b/candidates/templates/candidates/counties.html
@@ -5,7 +5,7 @@
     <title>立委投票指南: {{ad|ad_year}}候選人</title>
     <meta property="og:title" content="立委投票指南: {{ad|ad_year}}候選人"/>
     <meta itemprop="name" content="立委投票指南: {{ad|ad_year}}候選人">
-    <link href="//cdnjs.net/ajax/libs/semantic-ui/0.16.1/css/semantic.min.css" rel="stylesheet">
+    <link href="//semantic-ui.com/dist/semantic.min.css" rel="stylesheet">
     <script src="//semantic-ui.com/dist/semantic.min.js"></script>
 {% endblock title %}
 


### PR DESCRIPTION
semantic-ui is `v2.1.4` now, just change the url for ref to same version .css & .js .
(I think using `v0.16` on .css and `latest version` on .js is not fit in.)
